### PR TITLE
This fixed audio for me

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -1855,7 +1855,7 @@
 			<key>7C436110-AB2A-4BBB-A880-FE41995C9F82</key>
 			<dict>
 				<key>boot-args</key>
-				<string>npci=0x2000 alcid=11</string>
+				<string>npci=0x2000 alcid=1</string>
 				<key>csr-active-config</key>
 				<data>AAAAAA==</data>
 				<key>prev-lang:kbd</key>


### PR DESCRIPTION
I do highly advise setting the PciRoot value to 01000000 which is the hexadecimal for one instead of the line I changed but this is per motherboard and even this change may not fix many but it fixed mine and hey I got mic support working as well on AppleALC